### PR TITLE
Add Mercurial plugin feature to jenkins-job-builder

### DIFF
--- a/jenkins_jobs/modules/scm.py
+++ b/jenkins_jobs/modules/scm.py
@@ -106,12 +106,12 @@ def git(self, xml_parent, data):
 
       scm:
         - git:
-          url: https://example.com/project.git
-          branches:
-            - master
-            - stable
-          browser: githubweb
-          browser-url: http://github.com/foo/example.git
+            url: https://example.com/project.git
+            branches:
+              - master
+              - stable
+            browser: githubweb
+            browser-url: http://github.com/foo/example.git
     """
 
     # XXX somebody should write the docs for those with option name =
@@ -491,6 +491,91 @@ def tfs(self, xml_parent, data):
                                                   'plugins.tfs.browsers.'
                                                   'TeamSystemWebAccess'
                                                   'Browser'})
+
+
+def hg(self, xml_parent, data):
+    """yaml: hg
+    Specifies the mercurial SCM repository for this job.
+    Requires the Jenkins `Mercurial Plugin.
+    <https://wiki.jenkins-ci.org/display/JENKINS/Mercurial+Plugin>`_
+
+    :arg str url: URL of the hg repository
+    :arg str branch: the branch name if you'd like to track a specific branch
+      in a repository (optional)
+    :arg list(str) modules: reduce unnecessary builds by specifying a list of
+      "modules" within the repository. A module is a directory name within the
+      repository that this project lives in. (optional)
+    :arg bool clean: wipe any local modifications or untracked files in the
+      repository checkout (default false)
+    :arg str subdir: check out the Mercurial repository into this
+      subdirectory of the job's workspace (optional)
+    :arg str browser: what repository browser to use (default 'auto')
+    :arg str browser-url: url for the repository browser
+
+    :browser values:
+        :fisheye:
+        :bitbucketweb:
+        :googlecode:
+        :hgweb:
+        :kilnhg:
+        :rhodecode:
+        :rhodecodelegacy:
+
+    Example:
+
+      scm:
+        - hg:
+           branch: feature
+           url: ssh://hg@hg/repo
+           modules:
+             - module1
+             - module2
+           clean: true
+           browser: hgweb
+           browser-url: http://hg/repo
+
+    """
+    scm = XML.SubElement(xml_parent, 'scm', {'class':
+                         'hudson.plugins.mercurial.MercurialSCM'})
+    if 'url' in data:
+        XML.SubElement(scm, 'source').text = data['url']
+    else:
+        raise JenkinsJobsException("A top level url must exist")
+
+    if 'branch' in data:
+        XML.SubElement(scm, 'branch').text = data['branch']
+
+    if 'subdir' in data:
+        XML.SubElement(scm, 'subdir').text = data['subdir']
+
+    xc = XML.SubElement(scm, 'clean')
+    xc.text = str(data.get('clean', False)).lower()
+
+    xm = XML.SubElement(scm, 'modules')
+    if 'modules' in data:
+        xm.text = ' '.join(data['modules'])
+
+    browser = data.get('browser', 'auto')
+    browserdict = {'fisheye': 'FishEye',
+                   'bitbucketweb': 'BitBucket',
+                   'hgweb': 'HgWeb',
+                   'googlecode': 'GoogleCode',
+                   'kilnhg': 'KilnHG',
+                   'rhodecode': 'RhodeCode',
+                   'rhodecodelegacy': 'RhodeCodeLegacy',
+                   'auto': 'auto'}
+    if browser not in browserdict:
+        raise JenkinsJobsException("Browser entered is not valid must be one "
+                                   "of: %s" % ", ".join(browserdict.keys()))
+    if browser != 'auto':
+        bc = XML.SubElement(scm, 'browser', {'class':
+                            'hudson.plugins.mercurial.browser.' +
+                            browserdict[browser]})
+        if 'browser-url' in data:
+            XML.SubElement(bc, 'url').text = data['browser-url']
+        else:
+            raise JenkinsJobsException("A browser-url must be specified along "
+                                       "with browser.")
 
 
 class SCM(jenkins_jobs.modules.base.Base):

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,7 @@ setuptools.setup(
         ],
         'jenkins_jobs.scm': [
             'git=jenkins_jobs.modules.scm:git',
+            'hg=jenkins_jobs.modules.scm:hg',
             'repo=jenkins_jobs.modules.scm:repo',
             'svn=jenkins_jobs.modules.scm:svn',
             'tfs=jenkins_jobs.modules.scm:tfs',

--- a/tests/scm/fixtures/hg01.xml
+++ b/tests/scm/fixtures/hg01.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<project>
+  <scm class="hudson.plugins.mercurial.MercurialSCM">
+    <source>ssh://hg@hg/repo</source>
+    <clean>false</clean>
+    <modules/>
+  </scm>
+</project>

--- a/tests/scm/fixtures/hg01.yaml
+++ b/tests/scm/fixtures/hg01.yaml
@@ -1,0 +1,3 @@
+scm:
+  - hg:
+     url: ssh://hg@hg/repo

--- a/tests/scm/fixtures/hg02.xml
+++ b/tests/scm/fixtures/hg02.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<project>
+  <scm class="hudson.plugins.mercurial.MercurialSCM">
+    <source>ssh://hg@hg/repo</source>
+    <branch>feature</branch>
+    <clean>true</clean>
+    <modules>module1 module2</modules>
+    <browser class="hudson.plugins.mercurial.browser.HgWeb">
+      <url>http://hg/repo</url>
+    </browser>
+  </scm>
+</project>

--- a/tests/scm/fixtures/hg02.yaml
+++ b/tests/scm/fixtures/hg02.yaml
@@ -1,0 +1,10 @@
+scm:
+  - hg:
+     branch: feature
+     url: ssh://hg@hg/repo
+     modules:
+       - module1
+       - module2
+     clean: true
+     browser: hgweb
+     browser-url: http://hg/repo


### PR DESCRIPTION
Adds Mercurial plugin to jenkins-job-builder.
This allows you to use hg repositories in your Jenkins config
eg:
    scm:
      - hg:
         branch: feature
         url: ssh://hg@hg/repo
         modules:
           - module1
           - module2
         browser: hgweb
         browser-url: http://hg/repo

Fixed issues from code review.
Added test fixtures.

Change-Id: I134c8af15f0d4dc895f7131c77085c198b701fa8
Implements: blueprint jenkins-job-builder-mercurial
