### PR TITLE
Expose the Publish Over SHH Plugin entry point as a builder module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ jenkins_jobs.builders =
     sbt=jenkins_jobs.modules.builders:sbt
     shell=jenkins_jobs.modules.builders:shell
     shining-panda=jenkins_jobs.modules.builders:shining_panda
+    ssh=jenkins_jobs.modules.publishers:ssh
     trigger-builds=jenkins_jobs.modules.builders:trigger_builds
 jenkins_jobs.reporters =
     email=jenkins_jobs.modules.reporters:email


### PR DESCRIPTION
Expose the Publish Over SHH Pugin entry point as a builder module as this is supported by the plugin.

If feature changes can't be accepted through Github could someone please raise a ticket for this change?
