### PR TITLE
Added support for build-flow option "Flow run needs a workspace"

### DIFF
--- a/jenkins_jobs/modules/project_flow.py
+++ b/jenkins_jobs/modules/project_flow.py
@@ -48,4 +48,6 @@ class Flow(jenkins_jobs.modules.base.Base):
         else:
             XML.SubElement(xml_parent, 'dsl').text = ''
 
+        XML.SubElement(xml_parent, 'buildNeedsWorkspace').text = data.get('build-needs-workspace', 'false')
+
         return xml_parent


### PR DESCRIPTION
Added on 5/14, according to https://wiki.jenkins-ci.org/display/JENKINS/Build+Flow+Plugin, this option makes the DSL clone the repo.
