### PR TITLE
Add perlcritic capability to violations method

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -1004,7 +1004,7 @@ def violations(parser, xml_parent, data):
 
     Valid systems are:
 
-      checkstyle, codenarc, cpd, cpplint, csslint, findbugs, fxcop,
+      checkstyle, codenarc, cpd, cpplint, csslint, findbugs, fxcop, perlcritic
       gendarme, jcreport, jslint, pep8, pmd, pylint, simian, stylecop
 
     Example::
@@ -1042,6 +1042,7 @@ def violations(parser, xml_parent, data):
         'pmd',
         'pylint',
         'simian',
+        'perlcritic',
         'stylecop']:
         _violations_add_entry(configs, name, data.get(name, {}))
 


### PR DESCRIPTION
Latest version of jenkins-violation plugin have perlcritic support and this patch will add same capability for JJB. 

https://wiki.jenkins-ci.org/display/JENKINS/Violations
