### PR TITLE
Add `github_pending_status` builder module

### DIFF
--- a/jenkins_jobs/modules/builders.py
+++ b/jenkins_jobs/modules/builders.py
@@ -46,6 +46,22 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def github_pending_status(parser, xml_parent, data):
+    """yaml: github_pending_status
+    Set the pending status of the build on Github.
+    Requires the Jenkins `GitHub Plugin.
+    <https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin>`_
+
+    Example:
+
+      builders:
+        - github_pending_status
+    """
+    ghpend = XML.SubElement(xml_parent, 'com.cloudbees.jenkins.'
+                   'GitHubSetCommitStatusBuilder')
+    XML.SubElement(ghpend, 'spec').text = ''
+
+
 def shell(parser, xml_parent, data):
     """yaml: shell
     Execute a shell command.

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ jenkins_jobs.builders =
     copyartifact=jenkins_jobs.modules.builders:copyartifact
     critical-block-start=jenkins_jobs.modules.builders:critical_block_start
     critical-block-end=jenkins_jobs.modules.builders:critical_block_end
+    github-pending-status=jenkins_job.modules.builders:github_pending_status
     gradle=jenkins_jobs.modules.builders:gradle
     grails=jenkins_jobs.modules.builders:grails
     groovy=jenkins_jobs.modules.builders:groovy


### PR DESCRIPTION
Being able to add a build step that marked the build as pending on GitHub was added as an option to the [Jenkins Github module](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin) in version `1.1.10`.

This PR adds a builder that will enable this option currently.