### PR TITLE
Add support for disable-strict-forbidden-file-verification

### DIFF
--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -369,6 +369,14 @@ def gerrit(parser, xml_parent, data):
                               * **pattern** (`str`) -- Topic name pattern to
                                 match
 
+                * disable-strict-forbidden-file-verification (`bool`) --
+                      Enabling this option will allow an event to trigger a
+                      build if the event contains BOTH one or more wanted file
+                      paths AND one or more forbidden file paths.  In other
+                      words, with this option, the build will not get
+                      triggered if the change contains only forbidden files,
+                      otherwise it will get triggered.
+
     :arg dict skip-vote: map of build outcomes for which Jenkins must skip
         vote. Requires Gerrit Trigger Plugin version >= 2.7.0
 
@@ -522,6 +530,11 @@ def gerrit(parser, xml_parent, data):
                     get_compare_type('compare-type', topic.get('compare-type',
                                                                'PLAIN'))
                 XML.SubElement(topic_tag, 'pattern').text = topic['pattern']
+
+        XML.SubElement(gproj,
+                       'disableStrictForbiddenFileVerification').text = str(
+            project.get('disable-strict-forbidden-file-verification',
+                        False)).lower()
 
     build_gerrit_skip_votes(gtrig, data)
     XML.SubElement(gtrig, 'silentMode').text = str(

--- a/tests/jsonparser/fixtures/complete001.xml
+++ b/tests/jsonparser/fixtures/complete001.xml
@@ -62,6 +62,7 @@
               <pattern>**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
           </branches>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit001.xml
+++ b/tests/triggers/fixtures/gerrit001.xml
@@ -19,6 +19,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit002.xml
+++ b/tests/triggers/fixtures/gerrit002.xml
@@ -23,6 +23,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit003.xml
+++ b/tests/triggers/fixtures/gerrit003.xml
@@ -19,6 +19,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
           <compareType>PLAIN</compareType>
@@ -39,6 +40,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit004.xml
+++ b/tests/triggers/fixtures/gerrit004.xml
@@ -29,6 +29,7 @@
               <pattern>refactor-xy**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Topic>
           </topics>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit005.xml
+++ b/tests/triggers/fixtures/gerrit005.xml
@@ -19,6 +19,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit006.xml
+++ b/tests/triggers/fixtures/gerrit006.xml
@@ -19,6 +19,7 @@
               <pattern>subdirectory/**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePath>
           </filePaths>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit007.xml
+++ b/tests/triggers/fixtures/gerrit007.xml
@@ -29,6 +29,7 @@
               <pattern>refactor-xy**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Topic>
           </topics>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit008.xml
+++ b/tests/triggers/fixtures/gerrit008.xml
@@ -35,6 +35,7 @@
               <pattern>refactor-xy**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Topic>
           </topics>
+          <disableStrictForbiddenFileVerification>true</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>

--- a/tests/triggers/fixtures/gerrit008.yaml
+++ b/tests/triggers/fixtures/gerrit008.yaml
@@ -21,6 +21,7 @@ triggers:
           forbidden-file-paths:
               - compare-type: ANT
                 pattern: subdirectory/**
+          disable-strict-forbidden-file-verification: true
           topics:
               - compare-type: ANT
                 pattern: refactor-xy**

--- a/tests/yamlparser/fixtures/complete001.xml
+++ b/tests/yamlparser/fixtures/complete001.xml
@@ -62,6 +62,7 @@
               <pattern>**</pattern>
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
           </branches>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
         </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
       </gerritProjects>
       <skipVote>


### PR DESCRIPTION
Enabling this option will allow an event to trigger a build if the event
contains BOTH one or more wanted file paths AND one or more forbidden
file paths.  In other words, with this option, the build will not get
triggered if the change contains only forbidden files, otherwise it will
get triggered.

Support for this was added in Plugin Version 2.16.0.