### PR TITLE
Add user/password command line argument

### DIFF
--- a/jenkins_jobs/cmd.py
+++ b/jenkins_jobs/cmd.py
@@ -154,6 +154,14 @@ def create_parser():
         dest='allow_empty_variables', default=None,
         help='Don\'t fail if any of the variables inside any string are not '
         'defined, replace with empty string instead')
+    parser.add_argument(
+        '--user', '-u',
+        help='The Jenkins user to use for authentication. This overrides '
+        'the user specified in the configuration file')
+    parser.add_argument(
+        '--password', '-p',
+        help='Password or API token to use for authenticating towards Jenkins. '
+        'This overrides the password specified in the configuration file.')
 
     return parser
 
@@ -232,15 +240,21 @@ def execute(options, config):
     #
     # catching 'TypeError' is a workaround for python 2.6 interpolation error
     # https://bugs.launchpad.net/openstack-ci/+bug/1259631
-    try:
-        user = config.get('jenkins', 'user')
-    except (TypeError, configparser.NoOptionError):
-        user = None
+    if options.user:
+        user = options.user
+    else:
+        try:
+            user = config.get('jenkins', 'user')
+        except (TypeError, configparser.NoOptionError):
+            user = None
 
-    try:
-        password = config.get('jenkins', 'password')
-    except (TypeError, configparser.NoOptionError):
-        password = None
+    if options.password:
+        password = options.password
+    else:
+        try:
+            password = config.get('jenkins', 'password')
+        except (TypeError, configparser.NoOptionError):
+            password = None
 
     # Inform the user as to what is likely to happen, as they may specify
     # a real jenkins instance in test mode to get the plugin info to check


### PR DESCRIPTION
Some people prefer not to have any user or password in a config file. Both since if the config is under scm, it might be committed by accident.

Plus, this allows you to quickly test with a different Jenkins user without having to edit any files.