### PR TITLE
parser: Apply defaults to projects

### DIFF
--- a/jenkins_jobs/parser.py
+++ b/jenkins_jobs/parser.py
@@ -236,6 +236,7 @@ class YamlParser(object):
             self.jobs.append(job)
         for project in self.data.get('project', {}).values():
             logger.debug("Expanding project '{0}'".format(project['name']))
+            project = self._applyDefaults(project)
             # use a set to check for duplicate job references in projects
             seen = set()
             for jobspec in project.get('jobs', []):


### PR DESCRIPTION
[I'm aware that OpenStack disallows pull requests. However, I could not sign the ICLA on Gerrit ('Server error: could not store contact information'); maybe that's related to the fact I'm required - according to the documentation - to register as an OpenStack Foundation member. I refuse to join a foundation, which _requires_ me to participate in elections et al, to submit a one-line bugfix. If you want to clean-room this, describe the bugfix to someone and they can independently commit it. I'm submitting this PR solely as documentation, for the benefit of others who get caught out by this issue. Thanks, and I look forward to your contribution process becoming less hostile, as the docs claim there's work underway to accept contributions from people outside of the foundation.]


Also apply defaults to projects, allowing axis parameter expansion to
occur on projects as well. Previously, as default application did not
happen, attempting to use an axis defined through defaults for project
template substitution would result in a large explosion.

Example:
- job-template:
    name: 'foo/bar/{platform}-{arch}'

- project:
    name: 'foo/bar'
    jobs:
      - foo/bar/{platform}-{arch}

- defaults:
    platform:
      - debian-jessie
      - centos-7
    arch:
      - x86-64
      - armv7