### PR TITLE
 - Add "git-branch" & ""jenkins-encode" YAML tags

### DIFF
--- a/tests/localyaml/fixtures/git_branch.json
+++ b/tests/localyaml/fixtures/git_branch.json
@@ -1,0 +1,16 @@
+[
+    {
+        "job-template": {
+            "name": "test-job-{branch}"
+        }
+    },
+    {
+        "project": {
+            "name": "test-git-branch",
+            "branch": "master",
+            "jobs": [
+                "test-job-{branch}"
+            ]
+        }
+    }
+]

--- a/tests/localyaml/fixtures/git_branch.yaml
+++ b/tests/localyaml/fixtures/git_branch.yaml
@@ -1,0 +1,9 @@
+### Better testing setup needed! Tests break on "no git" or branch!=master
+- job-template:
+    name: "test-job-{branch}"
+
+- project:
+    name: "test-git-branch"
+    branch: !git-branch
+    jobs:
+      - "test-job-{branch}"

--- a/tests/localyaml/fixtures/json_encode.json
+++ b/tests/localyaml/fixtures/json_encode.json
@@ -1,0 +1,33 @@
+[
+    {
+        "project": {
+            "name": "test-json-encode",
+            "foo": "bar",
+            "json_var1": "[\"foo\", true, {{\"bar\": {{\"flat\": false}}}}]",
+            "var": "{{\"foo\": [\"bar\", 2, true]}}",
+            "jobs": [
+                {
+                    "test-job-json-encode-{label}": {
+                        "label": 1,
+                        "var": "[\"foo\", true, {{\"bar\": {{\"flat\": false}}}}]"
+                    }
+                },
+                {
+                    "test-job-json-encode-{label}": {
+                        "label": 2
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "job-template": {
+            "name": "test-job-json-encode-{label}",
+            "builders": [
+                {
+                    "shell": "echo {var}"
+                }
+            ]
+        }
+    }
+]

--- a/tests/localyaml/fixtures/json_encode.yaml
+++ b/tests/localyaml/fixtures/json_encode.yaml
@@ -1,0 +1,36 @@
+- project:
+    name: "test-json-encode"
+    foo: 'bar'
+    json_var1: !json-encode
+        - foo
+        - true
+        - bar:
+             flat: false
+    var: !json-encode
+        foo:
+            - bar
+            - 2
+            - true
+    jobs:
+      # Define {var} explicitly in the "arglist"
+      - "test-job-json-encode-{label}":
+          label: 1
+          var: !json-encode
+            - foo
+            - true
+            - bar:
+                 flat: false
+      # USe {var} implicityl from context
+      - "test-job-json-encode-{label}":
+          label: 2
+# Following use-case does not work - results in double-escaped curly braces due
+# to {var} being strformatted against the escaped version of the json output
+#      - "test-job-json-encode-{label}":
+#          label: 3
+#          var: '{json_var1}'
+
+- job-template:
+    name: "test-job-json-encode-{label}"
+    builders:
+        - shell: echo {var} 
+


### PR DESCRIPTION
     This custom YAML tag would allow auto-pickup of a git branch, based on the
     branch that the operator has checked out

 - Add "jenkins-encode" YAML tag
     Translates YAML sequences/mappins into JSON-encoded strings. This is
     useful for passing data structures around, e.g. from JJB definition into
     a Pipeline project.

Change-Id: Ia952b2d56541fdc2d0ebe8f1a9185b0d57ce9ef6