### PR TITLE
Accept rvm-version arg, to set correct ruby-class for new rvm plugin versions

### DIFF
--- a/jenkins_jobs/modules/wrappers.py
+++ b/jenkins_jobs/modules/wrappers.py
@@ -674,6 +674,8 @@ def rvm_env(registry, xml_parent, data):
 
     :arg str implementation: Type of implementation. Syntax is RUBY[@GEMSET],
                              such as '1.9.3' or 'jruby@foo'.
+    :arg str rvm-version: The version of the rvm plugin installed (optional)
+                          Versions '0.5' and up require a different ruby-class
 
     Example::
 
@@ -683,8 +685,10 @@ def rvm_env(registry, xml_parent, data):
     """
     rpo = XML.SubElement(xml_parent,
                          'ruby-proxy-object')
-
     ro_class = "Jenkins::Plugin::Proxies::BuildWrapper"
+    if data.get('rvm-version','0.4') >= '0.5':
+        ro_class = "Jenkins::Tasks::BuildWrapperProxy"
+
     ro = XML.SubElement(rpo,
                         'ruby-object',
                         {'ruby-class': ro_class,


### PR DESCRIPTION
This is to fix https://storyboard.openstack.org/#!/story/2000857 without breaking backwards compatibility for people still on rvm 0.4 and below.

Other options could be just updating to the new class name and documenting somewhere that jjb now only works with rvm 0.5+, working out what version is installed at runtime, or taking a different optional arg (for the exact class name or something?), but this seemed to be a reasonable compromise between usability and safety to me. It would be really useful to get something like this in anyway, because the 0.6 version of the rvm plugin has some good fixes in it.