### PR TITLE
fix(delete-all): fix delete-all command when no option is provided

### DIFF
--- a/jenkins_jobs/cli/subcommand/delete_all.py
+++ b/jenkins_jobs/cli/subcommand/delete_all.py
@@ -69,10 +69,10 @@ class DeleteAllSubCommand(base.BaseSubCommand):
                 'Job Builder)'.format(" AND ".join(reach))):
             sys.exit('Aborted')
 
-        if options.del_jobs:
+        if 'jobs' in reach:
             logger.info("Deleting all jobs")
             builder.delete_all_jobs()
 
-        if options.del_views:
+        if 'views' in reach:
             logger.info("Deleting all views")
             builder.delete_all_views()


### PR DESCRIPTION
Small fix to delete all jobs AND views in one shot.
Currently the workaround is to call the command twice, once to delete jobs only, once to delete views only.