### PR TITLE
Add option to provide credentials for scm:github:ssh-checkout

### DIFF
--- a/jenkins_jobs/modules/project_multibranch.py
+++ b/jenkins_jobs/modules/project_multibranch.py
@@ -660,7 +660,11 @@ def github_scm(xml_parent, data):
 
     :arg str api-uri: The GitHub API uri for hosted / on-site GitHub. Must
         first be configured in Global Configuration. (default GitHub)
-    :arg bool ssh-checkout: Checkout over SSH. (default false)
+    :arg bool ssh-checkout: Checkout over SSH.
+
+        * **credentials** ('str'): Credentials to use for
+            checkout of the repo over ssh.
+
     :arg str credentials-id: Credentials used to scan branches and pull
         requests, check out sources and mark commit statuses. (optional)
     :arg str repo-owner: Specify the name of the GitHub Organization or
@@ -736,12 +740,20 @@ def github_scm(xml_parent, data):
         helpers.convert_mapping_to_xml(
             bd, data, bd_mapping, fail_required=True)
 
-    if data.get('ssh-checkout', False):
-        XML.SubElement(
+    if data.get('ssh-checkout', None):
+        cossh = XML.SubElement(
             traits, ''.join([
                 github_path_dscore, '.SSHCheckoutTrait'
             ])
         )
+        cossh_credentials = [
+            ('credentials', 'credentialsId', ''),
+        ]
+        helpers.convert_mapping_to_xml(
+            cossh,
+            data.get('ssh-checkout'),
+            cossh_credentials,
+            fail_required=True)
 
     if data.get('discover-tags', False):
         XML.SubElement(

--- a/tests/multibranch/fixtures/scm_github_full.xml
+++ b/tests/multibranch/fixtures/scm_github_full.xml
@@ -41,7 +41,9 @@
             <org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait>
               <strategyId>3</strategyId>
             </org.jenkinsci.plugins.github__branch__source.BranchDiscoveryTrait>
-            <org.jenkinsci.plugins.github__branch__source.SSHCheckoutTrait/>
+            <org.jenkinsci.plugins.github__branch__source.SSHCheckoutTrait>
+              <credentialsId>ssh_secret</credentialsId>
+            </org.jenkinsci.plugins.github__branch__source.SSHCheckoutTrait>
             <org.jenkinsci.plugins.github__branch__source.TagDiscoveryTrait/>
             <org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait>
               <strategyId>3</strategyId>

--- a/tests/multibranch/fixtures/scm_github_full.yaml
+++ b/tests/multibranch/fixtures/scm_github_full.yaml
@@ -4,7 +4,8 @@ script-path: some.Jenkinsfile
 scm:
     - github:
         api-uri: http://example.org/github
-        ssh-checkout: true
+        ssh-checkout:
+            credentials: 'ssh_secret'
         repo: example-repo
         repo-owner: example-owner
         credentials-id: example-credential


### PR DESCRIPTION
same as existing bitbucket checkout-over-ssh, ssh-checkout for github
must needs the option for a user to specify the id of the secret
containing the ssh credentials to be used for checkout.