### PR TITLE
Add parser ref in Regsitry to addon iterate sub-nodes possibility + A…

### DIFF
--- a/jenkins_jobs/cli/subcommand/delete.py
+++ b/jenkins_jobs/cli/subcommand/delete.py
@@ -58,8 +58,8 @@ class DeleteSubCommand(base.BaseSubCommand):
                 '"--views-only" and "--jobs-only" cannot be used together.')
 
         fn = options.path
-        registry = ModuleRegistry(jjb_config, builder.plugins_list)
         parser = YamlParser(jjb_config)
+        registry = ModuleRegistry(jjb_config, parser, builder.plugins_list)
 
         if fn:
             parser.load_files(fn)

--- a/jenkins_jobs/cli/subcommand/list.py
+++ b/jenkins_jobs/cli/subcommand/list.py
@@ -54,9 +54,9 @@ class ListSubCommand(base.BaseSubCommand):
 
     def get_jobs(self, jobs_glob=None, fn=None):
         if fn:
-            r = registry.ModuleRegistry(self.jjb_config,
-                                      self.jenkins.plugins_list)
             p = parser.YamlParser(self.jjb_config)
+            r = registry.ModuleRegistry(self.jjb_config, p,
+                                      self.jenkins.plugins_list)
             p.load_files(fn)
             p.expandYaml(r, jobs_glob)
             jobs = [j['name'] for j in p.jobs]

--- a/jenkins_jobs/cli/subcommand/update.py
+++ b/jenkins_jobs/cli/subcommand/update.py
@@ -102,7 +102,7 @@ class UpdateSubCommand(base.BaseSubCommand):
 
         # Generate XML
         parser = YamlParser(jjb_config)
-        registry = ModuleRegistry(jjb_config, builder.plugins_list)
+        registry = ModuleRegistry(jjb_config, parser, builder.plugins_list)
         xml_job_generator = XmlJobGenerator(registry)
         xml_view_generator = XmlViewGenerator(registry)
 

--- a/jenkins_jobs/xml_config.py
+++ b/jenkins_jobs/xml_config.py
@@ -15,10 +15,13 @@
 
 # Manage Jenkins XML config file output.
 
+import logging
 import hashlib
 import pkg_resources
 from xml.dom import minidom
 import xml.etree.ElementTree as XML
+
+logger = logging.getLogger(__name__)
 
 from jenkins_jobs import errors
 
@@ -85,13 +88,15 @@ class XmlGenerator(object):
     def _getXMLForData(self, data):
         kind = data.get(self.kind_attribute, self.kind_default)
 
+        logging.debug("read module for {0} = {1}".format(self.kind_attribute, kind))
+
         for ep in pkg_resources.iter_entry_points(
                 group=self.entry_point_group, name=kind):
             Mod = ep.load()
             mod = Mod(self.registry)
             xml = mod.root_xml(data)
-            if "view-type" not in data:
-                self._gen_xml(xml, data)
+            #if "view-type" not in data:
+            self._gen_xml(xml, data)
             obj = XmlJob(xml, data['name'])
             return obj
 


### PR DESCRIPTION
This fix makes it possible to access configure sub-views of the NesteView view, this will be possible with this new feature implemented in the addons.

> Addons feature to support other Views (NesteViews, WorkflowPepilineVIew, others...) [#7](https://github.com/jimbydamonk/jenkins-job-builder-addons/pull/7)

- [Demo](https://github.com/itaborda/jenkins-job-builder-demo) using other views ( using this commit and addons  [#7](https://github.com/jimbydamonk/jenkins-job-builder-addons/pull/7) commits ) 