### PR TITLE
upstream-committers recipient provider

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2099,6 +2099,9 @@ def base_email_ext(registry, xml_parent, data, ttype):
             'culprits' in data['send-to']).lower()
         XML.SubElement(email, 'sendToRecipientList').text = str(
             'recipients' in data['send-to']).lower()
+        if 'upstream-committers' in data['send-to']:
+            XML.SubElement(email, 'recipientProviders',
+                           'hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider').text = ''
     else:
         XML.SubElement(email, 'sendToRequester').text = 'false'
         XML.SubElement(email, 'sendToDevelopers').text = 'false'

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2100,7 +2100,8 @@ def base_email_ext(registry, xml_parent, data, ttype):
         XML.SubElement(email, 'sendToRecipientList').text = str(
             'recipients' in data['send-to']).lower()
         if 'upstream-committers' in data['send-to']:
-            XML.SubElement(email, 'recipientProviders',
+            recipientProviders = XML.SubElement(email, 'recipientProviders')
+            XML.SubElement(recipientProviders,
                            'hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider').text = ''
     else:
         XML.SubElement(email, 'sendToRequester').text = 'false'

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2186,6 +2186,7 @@ def email_ext(registry, xml_parent, data):
             * **requester** (disabled by default)
             * **culprits** (disabled by default)
             * **recipients** (enabled by default)
+            * **upstream-committers** (disabled by default)
 
     Example:
 

--- a/tests/publishers/fixtures/email-ext001.xml
+++ b/tests/publishers/fixtures/email-ext001.xml
@@ -13,6 +13,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AlwaysTrigger>
         <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
@@ -24,6 +27,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
@@ -35,6 +41,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.FirstUnstableTrigger>
@@ -57,6 +66,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
         <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
@@ -68,6 +80,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
         <hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
@@ -79,6 +94,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
         <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
@@ -90,6 +108,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
@@ -101,6 +122,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
         <hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
@@ -112,6 +136,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
         <hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
@@ -123,6 +150,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
         <hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
@@ -134,6 +164,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedTrigger>
@@ -145,6 +178,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.FixedTrigger>
         <hudson.plugins.emailext.plugins.trigger.FixedUnhealthyTrigger>
@@ -167,6 +203,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
         <hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
@@ -178,6 +217,9 @@
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>
             <sendToRecipientList>true</sendToRecipientList>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.UpstreamComitterRecipientProvider/>
+            </recipientProviders>
           </email>
         </hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
       </configuredTriggers>

--- a/tests/publishers/fixtures/email-ext001.yaml
+++ b/tests/publishers/fixtures/email-ext001.yaml
@@ -33,3 +33,4 @@ publishers:
         - requester
         - culprits
         - recipients
+        - upstream-committers


### PR DESCRIPTION
This adds the recipient provider "upstream-committers" from the email-ext plugin.