### PR TITLE
Trigger specific subject and body

### DIFF
--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2173,6 +2173,12 @@ def email_ext(registry, xml_parent, data):
     :arg bool pre-build: Send an email before the build (default false)
     :arg str trigger-script: A Groovy script used to determine if an email
         should be sent.
+    :arg dict trigger-subject: Allows to define subject for the email specific
+        to triggers.
+        Name the trigger and a corresponding subject.
+    :arg dict trigger-body: Allows to define the content for the body of the
+        email specific to triggers.
+        Name the trigger and a corresponding body.
     :arg str presend-script: A Groovy script executed prior sending the mail.
         (default '')
     :arg str postsend-script: A Goovy script executed after sending the email.

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -2082,14 +2082,23 @@ def claim_build(registry, xml_parent, data):
     XML.SubElement(xml_parent, 'hudson.plugins.claim.ClaimPublisher')
 
 
-def base_email_ext(registry, xml_parent, data, ttype):
+def base_email_ext(registry, xml_parent, data, ttype, trigger_name):
     trigger = XML.SubElement(xml_parent,
                              'hudson.plugins.emailext.plugins.trigger.' +
                              ttype)
     email = XML.SubElement(trigger, 'email')
     XML.SubElement(email, 'recipientList').text = ''
-    XML.SubElement(email, 'subject').text = '$PROJECT_DEFAULT_SUBJECT'
-    XML.SubElement(email, 'body').text = '$PROJECT_DEFAULT_CONTENT'
+
+    subject = '$PROJECT_DEFAULT_SUBJECT'
+    if 'trigger-subject' in data and trigger_name in data['trigger-subject']:
+        subject = data['trigger-subject'][trigger_name]
+    XML.SubElement(email, 'subject').text = subject
+
+    body = '$PROJECT_DEFAULT_CONTENT'
+    if 'trigger-body' in data and trigger_name in data['trigger-body']:
+        body = data['trigger-body'][trigger_name]
+    XML.SubElement(email, 'body').text = body
+
     if 'send-to' in data:
         XML.SubElement(email, 'sendToDevelopers').text = str(
             'developers' in data['send-to']).lower()
@@ -2197,39 +2206,39 @@ def email_ext(registry, xml_parent, data):
         XML.SubElement(emailext, 'recipientList').text = '$DEFAULT_RECIPIENTS'
     ctrigger = XML.SubElement(emailext, 'configuredTriggers')
     if data.get('always', False):
-        base_email_ext(registry, ctrigger, data, 'AlwaysTrigger')
+        base_email_ext(registry, ctrigger, data, 'AlwaysTrigger', 'always')
     if data.get('unstable', False):
-        base_email_ext(registry, ctrigger, data, 'UnstableTrigger')
+        base_email_ext(registry, ctrigger, data, 'UnstableTrigger', 'unstable')
     if data.get('first-failure', False):
-        base_email_ext(registry, ctrigger, data, 'FirstFailureTrigger')
+        base_email_ext(registry, ctrigger, data, 'FirstFailureTrigger', 'first-failure')
     if data.get('first-unstable', False):
-        base_email_ext(registry, ctrigger, data, 'FirstUnstableTrigger')
+        base_email_ext(registry, ctrigger, data, 'FirstUnstableTrigger', 'first-unstable')
     if data.get('not-built', False):
-        base_email_ext(registry, ctrigger, data, 'NotBuiltTrigger')
+        base_email_ext(registry, ctrigger, data, 'NotBuiltTrigger', 'not-built')
     if data.get('aborted', False):
-        base_email_ext(registry, ctrigger, data, 'AbortedTrigger')
+        base_email_ext(registry, ctrigger, data, 'AbortedTrigger', 'aborted')
     if data.get('regression', False):
-        base_email_ext(registry, ctrigger, data, 'RegressionTrigger')
+        base_email_ext(registry, ctrigger, data, 'RegressionTrigger', 'regression')
     if data.get('failure', True):
-        base_email_ext(registry, ctrigger, data, 'FailureTrigger')
+        base_email_ext(registry, ctrigger, data, 'FailureTrigger', 'failure')
     if data.get('second-failure', False):
-        base_email_ext(registry, ctrigger, data, 'SecondFailureTrigger')
+        base_email_ext(registry, ctrigger, data, 'SecondFailureTrigger', 'second-failure')
     if data.get('improvement', False):
-        base_email_ext(registry, ctrigger, data, 'ImprovementTrigger')
+        base_email_ext(registry, ctrigger, data, 'ImprovementTrigger', 'improvement')
     if data.get('still-failing', False):
-        base_email_ext(registry, ctrigger, data, 'StillFailingTrigger')
+        base_email_ext(registry, ctrigger, data, 'StillFailingTrigger', 'still-failing')
     if data.get('success', False):
-        base_email_ext(registry, ctrigger, data, 'SuccessTrigger')
+        base_email_ext(registry, ctrigger, data, 'SuccessTrigger', 'success')
     if data.get('fixed', False):
-        base_email_ext(registry, ctrigger, data, 'FixedTrigger')
+        base_email_ext(registry, ctrigger, data, 'FixedTrigger', 'fixed')
     if data.get('fixed-unhealthy', False):
-        base_email_ext(registry, ctrigger, data, 'FixedUnhealthyTrigger')
+        base_email_ext(registry, ctrigger, data, 'FixedUnhealthyTrigger', 'fixed-unhealthy')
     if data.get('still-unstable', False):
-        base_email_ext(registry, ctrigger, data, 'StillUnstableTrigger')
+        base_email_ext(registry, ctrigger, data, 'StillUnstableTrigger', 'still-unstable')
     if data.get('pre-build', False):
-        base_email_ext(registry, ctrigger, data, 'PreBuildTrigger')
+        base_email_ext(registry, ctrigger, data, 'PreBuildTrigger', 'pre-build')
     if data.get('trigger-script', False):
-        base_email_ext(registry, ctrigger, data, 'ScriptTrigger')
+        base_email_ext(registry, ctrigger, data, 'ScriptTrigger', 'trigger-script')
 
     content_type_mime = {
         'text': 'text/plain',

--- a/tests/publishers/fixtures/email-ext001.xml
+++ b/tests/publishers/fixtures/email-ext001.xml
@@ -73,8 +73,8 @@
         <hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
           <email>
             <recipientList/>
-            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>$PROJECT_DEFAULT_CONTENT</body>
+            <subject>Subject specific to regression triggered email</subject>
+            <body>Body specific to regression triggered email</body>
             <sendToDevelopers>true</sendToDevelopers>
             <sendToRequester>true</sendToRequester>
             <includeCulprits>true</includeCulprits>

--- a/tests/publishers/fixtures/email-ext001.yaml
+++ b/tests/publishers/fixtures/email-ext001.yaml
@@ -25,6 +25,10 @@ publishers:
       still-unstable: true
       pre-build: true
       matrix-trigger: only-configurations
+      trigger-subject:
+          regression: Subject specific to regression triggered email
+      trigger-body:
+          regression: Body specific to regression triggered email
       presend-script: "cancel=true"
       postsend-script: "cancel=true"
       save-output: true

--- a/tests/publishers/fixtures/email-ext004.xml
+++ b/tests/publishers/fixtures/email-ext004.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <publishers>
+    <hudson.plugins.emailext.ExtendedEmailPublisher>
+      <recipientList>$DEFAULT_RECIPIENTS</recipientList>
+      <configuredTriggers>
+        <hudson.plugins.emailext.plugins.trigger.AlwaysTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'always' triggered email</subject>
+            <body>Body specific to 'always' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.AlwaysTrigger>
+        <hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'unstable' triggered email</subject>
+            <body>Body specific to 'unstable' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.UnstableTrigger>
+        <hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'first-failure' triggered email</subject>
+            <body>Body specific to 'first-failure' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger>
+        <hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'not-built' triggered email</subject>
+            <body>Body specific to 'not-built' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.NotBuiltTrigger>
+        <hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'aborted' triggered email</subject>
+            <body>Body specific to 'aborted' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.AbortedTrigger>
+        <hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'regression' triggered email</subject>
+            <body>Body specific to 'regression' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.RegressionTrigger>
+        <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'failure' triggered email</subject>
+            <body>Body specific to 'failure' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+        <hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'second-failure' triggered email</subject>
+            <body>Body specific to 'second-failure' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.SecondFailureTrigger>
+        <hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'improvement' triggered email</subject>
+            <body>Body specific to 'improvement' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.ImprovementTrigger>
+        <hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'still-failing' triggered email</subject>
+            <body>Body specific to 'still-failing' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.StillFailingTrigger>
+        <hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'success' triggered email</subject>
+            <body>Body specific to 'success' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.SuccessTrigger>
+        <hudson.plugins.emailext.plugins.trigger.FixedTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'fixed' triggered email</subject>
+            <body>Body specific to 'fixed' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FixedTrigger>
+        <hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'still-unstable' triggered email</subject>
+            <body>Body specific to 'still-unstable' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.StillUnstableTrigger>
+        <hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'pre-build' triggered email</subject>
+            <body>Body specific to 'pre-build' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.PreBuildTrigger>
+        <hudson.plugins.emailext.plugins.trigger.ScriptTrigger>
+          <email>
+            <recipientList/>
+            <subject>Subject specific to 'trigger-script' triggered email</subject>
+            <body>Body specific to 'trigger-script' triggered email</body>
+            <sendToDevelopers>true</sendToDevelopers>
+            <sendToRequester>true</sendToRequester>
+            <includeCulprits>true</includeCulprits>
+            <sendToRecipientList>true</sendToRecipientList>
+          </email>
+          <triggerScript>build.result.toString().equals('SUCCESS')</triggerScript>
+        </hudson.plugins.emailext.plugins.trigger.ScriptTrigger>
+      </configuredTriggers>
+      <contentType>text/html</contentType>
+      <defaultSubject>Subject for Build ${BUILD_NUMBER}</defaultSubject>
+      <defaultContent>The build has finished</defaultContent>
+      <attachmentsPattern/>
+      <presendScript/>
+      <postsendScript/>
+      <attachBuildLog>false</attachBuildLog>
+      <compressBuildLog>false</compressBuildLog>
+      <saveOutput>false</saveOutput>
+      <disabled>false</disabled>
+      <replyTo>$DEFAULT_REPLYTO</replyTo>
+    </hudson.plugins.emailext.ExtendedEmailPublisher>
+  </publishers>
+</project>

--- a/tests/publishers/fixtures/email-ext004.yaml
+++ b/tests/publishers/fixtures/email-ext004.yaml
@@ -1,0 +1,57 @@
+publishers:
+  - email-ext:
+      content-type: html
+      subject: Subject for Build ${BUILD_NUMBER}
+      body: The build has finished
+      always: true
+      unstable: true
+      first-failure: true
+      not-built: true
+      aborted: true
+      regression: true
+      failure: true
+      second-failure: true
+      improvement: true
+      still-failing: true
+      success: true
+      fixed: true
+      still-unstable: true
+      pre-build: true
+      trigger-script: "build.result.toString().equals('SUCCESS')"
+      trigger-subject:
+          always: Subject specific to 'always' triggered email
+          unstable: Subject specific to 'unstable' triggered email
+          first-failure: Subject specific to 'first-failure' triggered email
+          not-built: Subject specific to 'not-built' triggered email
+          aborted: Subject specific to 'aborted' triggered email
+          regression: Subject specific to 'regression' triggered email
+          failure: Subject specific to 'failure' triggered email
+          second-failure: Subject specific to 'second-failure' triggered email
+          improvement: Subject specific to 'improvement' triggered email
+          still-failing: Subject specific to 'still-failing' triggered email
+          success: Subject specific to 'success' triggered email
+          fixed: Subject specific to 'fixed' triggered email
+          still-unstable: Subject specific to 'still-unstable' triggered email
+          pre-build: Subject specific to 'pre-build' triggered email
+          trigger-script: Subject specific to 'trigger-script' triggered email
+      trigger-body:
+          always: Body specific to 'always' triggered email
+          unstable: Body specific to 'unstable' triggered email
+          first-failure: Body specific to 'first-failure' triggered email
+          not-built: Body specific to 'not-built' triggered email
+          aborted: Body specific to 'aborted' triggered email
+          regression: Body specific to 'regression' triggered email
+          failure: Body specific to 'failure' triggered email
+          second-failure: Body specific to 'second-failure' triggered email
+          improvement: Body specific to 'improvement' triggered email
+          still-failing: Body specific to 'still-failing' triggered email
+          success: Body specific to 'success' triggered email
+          fixed: Body specific to 'fixed' triggered email
+          still-unstable: Body specific to 'still-unstable' triggered email
+          pre-build: Body specific to 'pre-build' triggered email
+          trigger-script: Body specific to 'trigger-script' triggered email
+      send-to:
+        - developers
+        - requester
+        - culprits
+        - recipients


### PR DESCRIPTION
This enables setting a trigger-specific subject or body for a message when configuring email-ext notifications.